### PR TITLE
Fix D10 compatibility

### DIFF
--- a/diocesan_directory.info.yml
+++ b/diocesan_directory.info.yml
@@ -1,8 +1,7 @@
 name: Diocesan Directory
 type: module
 description: Diocesan parishes, schools, agencies, etc...
-core: 8.x
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^8.8 || ^9 || ^10
 package: Custom
 dependencies:
   - address

--- a/src/Entity/DefaultEntityType.php
+++ b/src/Entity/DefaultEntityType.php
@@ -40,6 +40,10 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *     "edit-form" = "/admin/structure/directory_type/{directory_type}/edit",
  *     "delete-form" = "/admin/structure/directory_type/{directory_type}/delete",
  *     "collection" = "/admin/structure/directory_type"
+ *   },
+ *   config_export= {
+ *     "id",
+ *     "label",
  *   }
  * )
  */

--- a/templates/directory-content-add-list.html.twig
+++ b/templates/directory-content-add-list.html.twig
@@ -14,10 +14,10 @@
  * @ingroup themeable
  */
 #}
-{% spaceless %}
+{% apply spaceless %}
   <dl>
     {% for type in types %}
       <dt>{{ type.link }}</dt>
     {% endfor %}
   </dl>
-{% endspaceless %}
+{% endapply %}


### PR DESCRIPTION
- [Add config_exports to support D9](https://github.com/FaithCatholic/diocesan_directory/commit/104cbb43a44b9ecd9a370d83fb9de2426541c903): See https://www.drupal.org/node/2949023
- [Fix custom content listing template for D10](https://github.com/FaithCatholic/diocesan_directory/commit/f341153d4fc21cce92476d77ac4b6fedfc09d905): The spaceless tag was deprecated in Twig 2.7.
See https://twig.symfony.com/doc/2.x/deprecated.html#tags